### PR TITLE
Bug fix so the push button populates the table widget on shortest custom

### DIFF
--- a/app/Database.cpp
+++ b/app/Database.cpp
@@ -41,7 +41,7 @@ Database::Database(): QSqlDatabase(addDatabase("QSQLITE"))
         QString windowsPathFile =  "/db/NFLdb.db";
         setDatabaseName(QDir::currentPath() + windowsPathFile);
 
-//        QString BLAKESPATH = "/Users/blakedickerson/Downloads/nfldb.db";
+  //      QString BLAKESPATH = "/Users/blakedickerson/Downloads/nfldb.db";
 //       setDatabaseName(BLAKESPATH);
         setDatabaseName(QDir::currentPath() + windowsPathFile);
         qDebug() << QDir::currentPath() + windowsPathFile;

--- a/app/SouvenirAndTrip.h
+++ b/app/SouvenirAndTrip.h
@@ -158,8 +158,6 @@ private slots:
 
     void on_customTrip_cart_button_clicked();
 
-private:
-
     /*!
      * @brief Finalizes the custom shortest trip. Runs trip.
      */


### PR DESCRIPTION
Populates the table widget with the correct output. Was not able to populate table widget beforehand.